### PR TITLE
Updated the biome log check to check if it's in a Discord rich presence

### DIFF
--- a/source_code (IMPORTANT!)/biome_activity_source.py
+++ b/source_code (IMPORTANT!)/biome_activity_source.py
@@ -1481,7 +1481,7 @@ class BiomePresence():
 
             for line in reversed(log_lines):
                 for biome in self.biome_data:
-                    if biome in line:
+                    if f'"largeImage":{{"hoverText":"{biome}"' in line:
                         threading.Thread(target=self.handle_biome_detection, args=(biome,)).start()
                         return
 


### PR DESCRIPTION
Instead of only checking if a biome is in the log line, it must also contain part of the Discord rich presence.
_I have not tested this._